### PR TITLE
Add CheckCommand.

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -8,7 +8,7 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_ILLEGAL_VALUE = "Illegal value: ";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
+    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
 
 }

--- a/src/main/java/seedu/address/logic/commands/CheckCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CheckCommand.java
@@ -1,0 +1,65 @@
+package seedu.address.logic.commands;
+
+import javafx.collections.ObservableList;
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+
+/**
+ * Checks a selected Buyer/Supplier/Order/Pet.
+ */
+public class CheckCommand extends Command {
+
+    public static final String COMMAND_WORD = "check";
+
+    public static final String MESSAGE_USAGE = "Check the buyer/supplier of a specific order/pet with.\n"
+            + "Example: check order 1";
+
+    public static final String MESSAGE_SUCCESS = "Checking %1$s %2$s";
+
+    public static final String CHECK_BUYER = "BUYER";
+
+    public static final String CHECK_SUPPLIER = "SUPPLIER";
+    public static final String CHECK_ORDER = "ORDER";
+    public static final String CHECK_PET = "PET";
+
+    private final String checkType;
+    private final Index index;
+
+    /**
+     * Constructs a CheckCommand with fields specified.
+     */
+    public CheckCommand(String checkType, Index index) {
+        this.checkType = checkType;
+        this.index = index;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        switch (checkType) {
+        case CHECK_BUYER:
+            invalidIndexThrowException(model.getFilteredBuyerList());
+            break;
+        case CHECK_SUPPLIER:
+            invalidIndexThrowException(model.getFilteredSupplierList());
+            break;
+        case CHECK_ORDER:
+            invalidIndexThrowException(model.getFilteredOrderList());
+            break;
+        case CHECK_PET:
+            invalidIndexThrowException(model.getFilteredPetList());
+            break;
+        default:
+            //Do nothing
+        }
+        return new CommandResult(String.format(MESSAGE_SUCCESS, checkType, index.getOneBased()),
+                true, checkType, index);
+    }
+
+    private void invalidIndexThrowException(ObservableList<? extends Object> list) throws CommandException {
+        if (index.getZeroBased() >= list.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -4,6 +4,9 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
 
+import seedu.address.commons.core.index.Index;
+
+
 /**
  * Represents the result of a command execution.
  */
@@ -24,16 +27,75 @@ public class CommandResult {
      * Specifies which group to list.
      */
     private final String listType;
+    /**
+     * The application should check a selected object.
+     */
+    private final boolean check;
+    /**
+     * Specifies which group of objects to check.
+     */
+    private final String checkType;
+    /**
+     * Specifies the index of object to check
+     */
+    private final Index index;
 
     /**
      * Constructs a {@code CommandResult} with the specified fields.
      */
-    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit, boolean list, String listType) {
+    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit, boolean list, String listType,
+                         boolean check, String checkType, Index index) {
         this.feedbackToUser = requireNonNull(feedbackToUser);
         this.showHelp = showHelp;
         this.exit = exit;
         this.list = list;
         this.listType = listType;
+        this.check = check;
+        this.checkType = checkType;
+        this.index = index;
+    }
+
+
+    /**
+     * Constructs a {@code CommandResult} with showHelp and showExit fields specified.
+     */
+    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit) {
+        this.feedbackToUser = requireNonNull(feedbackToUser);
+        this.showHelp = showHelp;
+        this.exit = exit;
+        this.list = false;
+        this.listType = null;
+        this.check = false;
+        this.checkType = null;
+        this.index = null;
+    }
+
+    /**
+     * Constructs a {@code CommandResult} with list and listType fields specified.
+     */
+    public CommandResult(String feedbackToUser, boolean list, String listType) {
+        this.feedbackToUser = requireNonNull(feedbackToUser);
+        this.showHelp = false;
+        this.exit = false;
+        this.list = list;
+        this.listType = listType;
+        this.check = false;
+        this.checkType = null;
+        this.index = null;
+    }
+
+    /**
+     * Constructs a {@code CommandResult} with check, checkType and Index fields specified.
+     */
+    public CommandResult(String feedbackToUser, boolean check, String checkType, Index index) {
+        this.feedbackToUser = requireNonNull(feedbackToUser);
+        this.showHelp = false;
+        this.exit = false;
+        this.list = false;
+        this.listType = null;
+        this.check = check;
+        this.checkType = checkType;
+        this.index = index;
     }
 
     /**
@@ -41,7 +103,7 @@ public class CommandResult {
      * and other fields set to their default value.
      */
     public CommandResult(String feedbackToUser) {
-        this(feedbackToUser, false, false, false, null);
+        this(feedbackToUser, false, false, false, null, false, null, null);
     }
 
     public String getFeedbackToUser() {
@@ -58,6 +120,18 @@ public class CommandResult {
 
     public boolean isList() {
         return list;
+    }
+
+    public boolean isCheck() {
+        return check;
+    }
+
+    public String getCheckType() {
+        return checkType;
+    }
+
+    public Index getIndex() {
+        return index;
     }
 
     public String getListType() {
@@ -79,12 +153,19 @@ public class CommandResult {
         return feedbackToUser.equals(otherCommandResult.feedbackToUser)
                 && showHelp == otherCommandResult.showHelp
                 && exit == otherCommandResult.exit
-                && list == otherCommandResult.list;
+                && list == otherCommandResult.list
+                && ((listType == null && otherCommandResult.listType == null)
+                    || (listType != null && listType.equals(otherCommandResult.listType)))
+                && check == otherCommandResult.check
+                && ((checkType == null && otherCommandResult.checkType == null)
+                    || (checkType != null && checkType.equals(otherCommandResult.checkType)))
+                && ((index == null && otherCommandResult.index == null)
+                    || (index != null && index.equals(otherCommandResult.index)));
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(feedbackToUser, showHelp, exit, list);
+        return Objects.hash(feedbackToUser, showHelp, exit, list, listType, check, checkType, index);
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommand.java
@@ -13,7 +13,7 @@ public class ExitCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true, false, null);
+        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true);
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -16,6 +16,6 @@ public class HelpCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(SHOWING_HELP_MESSAGE, true, false, false, null);
+        return new CommandResult(SHOWING_HELP_MESSAGE, true, false);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -40,9 +40,9 @@ public class ListCommand extends Command {
         model.updateFilteredPetList(Model.PREDICATE_SHOW_ALL_PETS);
         model.updateFilteredOrderList(Model.PREDICATE_SHOW_ALL_ORDERS);
         if (this.listType == ListCommand.LIST_EMPTY) {
-            return new CommandResult(MESSAGE_SUCCESS_EMPTY, false, false, true, listType);
+            return new CommandResult(MESSAGE_SUCCESS_EMPTY, true, listType);
         }
-        return new CommandResult(String.format(MESSAGE_SUCCESS, listType), false, false, true, listType);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, listType), true, listType);
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -7,6 +7,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import seedu.address.logic.commands.AddPersonCommand;
+import seedu.address.logic.commands.CheckCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteBuyerCommand;
@@ -97,6 +98,9 @@ public class AddressBookParser {
 
         case ListCommand.COMMAND_WORD:
             return new ListCommandParser().parse(arguments);
+
+        case CheckCommand.COMMAND_WORD:
+            return new CheckCommandParser().parse(arguments);
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/seedu/address/logic/parser/CheckCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CheckCommandParser.java
@@ -1,0 +1,51 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.CheckCommand;
+import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.util.CommandUtil;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new ListCommand object.
+ */
+public class CheckCommandParser implements Parser<CheckCommand> {
+
+    private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<checkType>.\\S*)(?<index>.\\d*)");
+
+    @Override
+    public CheckCommand parse(String userInput) throws ParseException {
+        final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
+        if (!matcher.matches()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+        }
+
+        final String checkType = matcher.group("checkType");
+        final String indexStr = matcher.group("index");
+        Index index = ParserUtil.parseIndex(indexStr);
+
+        if (CommandUtil.isValidParameter(CommandUtil.ACCEPTABLE_BUYER_PARAMETER, checkType)) {
+            return new CheckCommand(CheckCommand.CHECK_BUYER, index);
+        }
+
+        if (CommandUtil.isValidParameter(CommandUtil.ACCEPTABLE_SUPPLIER_PARAMETER, checkType)) {
+            return new CheckCommand(CheckCommand.CHECK_SUPPLIER, index);
+        }
+
+        if (CommandUtil.isValidParameter(CommandUtil.ACCEPTABLE_ORDER_PARAMETER, checkType)) {
+            return new CheckCommand(CheckCommand.CHECK_ORDER, index);
+        }
+
+        if (CommandUtil.isValidParameter(CommandUtil.ACCEPTABLE_PET_PARAMETER, checkType)) {
+            return new CheckCommand(CheckCommand.CHECK_PET, index);
+        }
+
+        throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, CheckCommand.MESSAGE_USAGE));
+
+    }
+}

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -2,6 +2,8 @@ package seedu.address.ui;
 
 import java.util.logging.Logger;
 
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.scene.control.MenuItem;
@@ -12,10 +14,17 @@ import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Logic;
+import seedu.address.logic.commands.CheckCommand;
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.order.Order;
+import seedu.address.model.person.Buyer;
+import seedu.address.model.person.Supplier;
+import seedu.address.model.pet.Pet;
 
 /**
  * The Main Window. Provides the basic application layout containing
@@ -232,35 +241,77 @@ public class MainWindow extends UiPart<Stage> {
     }
 
     /**
-     * Handles the behaviour of window to display for list command.
+     * Handles the window display behaviour for list command.
      */
     public void handleList(String list) {
         list = list.trim().toUpperCase();
         switch(list) {
-        case "BUYER":
+        case ListCommand.LIST_BUYER:
             showBuyer();
             break;
-        case "SUPPLIER":
+        case ListCommand.LIST_SUPPLIER:
             showSupplier();
             break;
-        case "DELIVERER":
+        case ListCommand.LIST_DELIVERER:
             showDeliverer();
             break;
-        case "ORDER":
+        case ListCommand.LIST_ORDER:
             showOrder();
             break;
-        case "PET":
+        case ListCommand.LIST_PET:
             showPet();
             break;
-        case "ALL":
+        case ListCommand.LIST_ALL:
             showAll();
             break;
-        case "EMPTY":
+        case ListCommand.LIST_EMPTY:
             //Fall through
         default:
             //Do nothing
         }
     }
+
+    /**
+     * Handles the display for CheckCommand.
+     * @param index The index of the item needs to be checked.
+     */
+    public void handleCheck(String checkType, int index) {
+        checkType = checkType.trim().toUpperCase();
+        switch (checkType) {
+        case CheckCommand.CHECK_BUYER:
+            Buyer buyer = logic.getFilteredBuyerList().get(index);
+            ObservableList<Order> buyerOrderList = logic.getOrderAsObservableListFromBuyer(buyer);
+            OrderListPanel newOrderList = new OrderListPanel(buyerOrderList);
+            personListPanelPlaceholder.getChildren().clear();
+            personListPanelPlaceholder.getChildren().add(newOrderList.getRoot());
+            break;
+        case CheckCommand.CHECK_SUPPLIER:
+            Supplier supplier = logic.getFilteredSupplierList().get(index);
+            ObservableList<Pet> supplierPetList = logic.getPetAsObservableListFromSupplier(supplier);
+            PetListPanel newPetList = new PetListPanel(supplierPetList);
+            personListPanelPlaceholder.getChildren().clear();
+            personListPanelPlaceholder.getChildren().add(newPetList.getRoot());
+            break;
+        case CheckCommand.CHECK_ORDER:
+            Order order = logic.getFilteredOrderList().get(index);
+            ObservableList<Order> orders = FXCollections.singletonObservableList(order);
+            OrderListPanel tempOrderPanel = new OrderListPanel(orders);
+            personListPanelPlaceholder.getChildren().clear();
+            personListPanelPlaceholder.getChildren().add(tempOrderPanel.getRoot());
+            break;
+        case CheckCommand.CHECK_PET:
+            Pet pet = logic.getFilteredPetList().get(index);
+            ObservableList<Pet> pets = FXCollections.singletonObservableList(pet);
+            PetListPanel tempPetPanel = new PetListPanel(pets);
+            personListPanelPlaceholder.getChildren().clear();
+            personListPanelPlaceholder.getChildren().add(tempPetPanel.getRoot());
+            break;
+        default:
+            //Do nothing
+        }
+
+    }
+
 
     /**
      * Executes the command and returns the result.
@@ -283,6 +334,11 @@ public class MainWindow extends UiPart<Stage> {
 
             if (commandResult.isList()) {
                 handleList(commandResult.getListType());
+            }
+
+            if (commandResult.isCheck()) {
+                Index index = commandResult.getIndex();
+                handleCheck(commandResult.getCheckType(), index.getZeroBased());
             }
 
             return commandResult;

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -14,8 +14,7 @@ public class CommandResultTest {
 
         // same values -> returns true
         assertTrue(commandResult.equals(new CommandResult("feedback")));
-        assertTrue(commandResult.equals(new CommandResult("feedback", false, false,
-                false, null)));
+        assertTrue(commandResult.equals(new CommandResult("feedback", false, false)));
 
         // same object -> returns true
         assertTrue(commandResult.equals(commandResult));
@@ -30,12 +29,10 @@ public class CommandResultTest {
         assertFalse(commandResult.equals(new CommandResult("different")));
 
         // different showHelp value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", true, false,
-                false, null)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", true, false)));
 
         // different exit value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, true,
-                false, null)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, true)));
     }
 
     @Test
@@ -49,11 +46,9 @@ public class CommandResultTest {
         assertNotEquals(commandResult.hashCode(), new CommandResult("different").hashCode());
 
         // different showHelp value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", true, false,
-                false, null).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", true, false).hashCode());
 
         // different exit value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, true,
-                false, null).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, true).hashCode());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
@@ -15,7 +15,7 @@ public class ExitCommandTest {
     @Test
     public void execute_exit_success() {
         CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false,
-                true, false, null);
+                true);
         assertCommandSuccess(new ExitCommand(), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
@@ -14,8 +14,7 @@ public class HelpCommandTest {
 
     @Test
     public void execute_help_success() {
-        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false,
-                false, null);
+        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false);
         assertCommandSuccess(new HelpCommand(), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -28,15 +28,15 @@ public class ListCommandTest {
 
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
-        CommandResult expectedCommandResult = new CommandResult(ListCommand.MESSAGE_SUCCESS_EMPTY, false,
-                false, true, ListCommand.LIST_EMPTY);
+        CommandResult expectedCommandResult = new CommandResult(ListCommand.MESSAGE_SUCCESS_EMPTY,
+                true, ListCommand.LIST_EMPTY);
         assertCommandSuccess(new ListCommand(ListCommand.LIST_EMPTY), model, expectedCommandResult, expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
-        CommandResult expectedCommandResult = new CommandResult(ListCommand.MESSAGE_SUCCESS_EMPTY, false,
-                false, true, ListCommand.LIST_EMPTY);
+        CommandResult expectedCommandResult = new CommandResult(ListCommand.MESSAGE_SUCCESS_EMPTY,
+                true, ListCommand.LIST_EMPTY);
         showBuyerAtIndex(model, INDEX_FIRST);
         assertCommandSuccess(new ListCommand(ListCommand.LIST_EMPTY), model, expectedCommandResult,
                 expectedModel);
@@ -46,8 +46,7 @@ public class ListCommandTest {
     public void execute_listBuyer_success() {
         CommandResult expectedCommandResult = new CommandResult(
                 String.format(ListCommand.MESSAGE_SUCCESS, ListCommand.LIST_BUYER),
-                false,
-                false, true, ListCommand.LIST_BUYER);
+                true, ListCommand.LIST_BUYER);
         assertCommandSuccess(new ListCommand(ListCommand.LIST_BUYER), model, expectedCommandResult,
                 expectedModel);
     }


### PR DESCRIPTION
Add CheckCommand.

Syntax: `check [list_parameter] [index]`
Example: `check buyer 1`, `check pet 2`, `check order 5`

**Note this check command does not support deliverer list**

UI behaviour: The UI is expected to show the respective output from the command immediately. In other words, this command is expected to change the display window of the UI.

Also Note that the index is based on the filtered list. For instance, if filtered list contains a predicate such that no elements are shown on the UI display page. Then any index in this case will be an invalid index.

Acceptable list parameters:
Buyer: Buyer/b/-b
Supplier: Supplier/s/-s
Order: order/o/-o
Pet: pet/p/-p